### PR TITLE
AIボット連携の追加: Anthropic SDK 導入とチャットAPI実装

### DIFF
--- a/InteractiveManga/package-lock.json
+++ b/InteractiveManga/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.62.0",
         "@types/node": "^24.3.3",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
@@ -17,6 +18,15 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.62.0.tgz",
+      "integrity": "sha512-gT2VFKX0gSp7KJNlav/vzRFjJOPYDZxCJRx7MYUc+fqURc5aS6OI/UJeD2KytJkjsIWv0OOwH1ePc1S5QE2GZw==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/InteractiveManga/package.json
+++ b/InteractiveManga/package.json
@@ -13,10 +13,11 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "lucide-react": "^0.463.0",
+    "@anthropic-ai/sdk": "^0.62.0",
     "@types/node": "^24.3.3",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
+    "lucide-react": "^0.463.0",
     "next": "^15.5.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",


### PR DESCRIPTION
以下を追加・更新しました:

- Next.js API ルート `app/api/chat/route.ts` を実装し、Anthropic Messages API へのプロキシを追加
- クライアント側 `index.html` からの AI チャット呼び出しを有効化（`window.__ANTHROPIC_API_KEY`/`__ANTHROPIC_MODEL` 参照）
- 依存関係に `@anthropic-ai/sdk` を追加
- `.env*` は `.gitignore` で除外済み（`.env.local` に API キーを設定して動作確認）

想定動作:
- `npm run dev` で Next.js を起動し、`/api/chat` に POST すると Claude から応答が返ります。
- スタンドアロン `index.html` でも `window.__ANTHROPIC_API_KEY` を設定すれば動作します。

補足:
- 公開リポジトリでは API キーを絶対にコミットしないでください。Vercel などの環境変数を使用してください。
